### PR TITLE
Add / Update: Temperature 参数说明气泡

### DIFF
--- a/app/src/main/java/com/meapet/mobile/ui/screen/settings/ProviderSettings.kt
+++ b/app/src/main/java/com/meapet/mobile/ui/screen/settings/ProviderSettings.kt
@@ -219,10 +219,14 @@ internal fun ModelParamsSection(
 
     Spacer(Modifier.height(8.dp))
 
-    Text(
-        text = "Temperature: ${"%.2f".format(local.temperature)}",
-        style = MaterialTheme.typography.bodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
+    ParamLabelWithHelp(
+        label = "Temperature: ${"%.2f".format(local.temperature)}",
+        helpTitle = "Temperature（随机度）",
+        helpText = "决定回复的随机程度。数值越低，模型越倾向挑高概率的词，回答更稳定、" +
+            "更贴合设定；越高则用词更多样、更有意外感，但也更容易偏题或前后矛盾。\n\n" +
+            "桌宠闲聊建议 0.8~1.2；需要它严格听指令时降到 0.3 以下。\n\n" +
+            "注意：设为 0 也不保证每次输出完全一致；部分提供商上限为 1.0，" +
+            "推理模型会忽略此参数。"
     )
     Slider(
         value = local.temperature,

--- a/app/src/main/java/com/meapet/mobile/ui/screen/settings/SettingsCommon.kt
+++ b/app/src/main/java/com/meapet/mobile/ui/screen/settings/SettingsCommon.kt
@@ -1,5 +1,6 @@
 package com.meapet.mobile.ui.screen.settings
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -7,22 +8,36 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.meapet.mobile.R
+import kotlinx.coroutines.launch
 
 // ═══════════════════════════════════════════════════
 //  设置页公共件：视觉常量、Slider 规格、基础行/分组组件
@@ -86,6 +101,68 @@ internal const val TTS_SPEED_STEPS = 14
 /** 失焦时保存的扩展（统一 onFocusChanged 样板）。 */
 internal fun Modifier.saveOnFocusChange(action: () -> Unit): Modifier =
     onFocusChanged { if (!it.isFocused) action() }
+
+/**
+ * 带说明气泡的参数标签：文字 + 一个问号图标，点图标弹出 [RichTooltip] 讲解该参数。
+ *
+ * `isPersistent = true` 且关掉 `enableUserInput`：默认手势是长按/悬停且会超时自行消失，
+ * 说明文字来不及读完。改为图标 onClick 主动 `show()`。
+ *
+ * @param label 参数名与当前值，如 `Temperature: 0.70`
+ * @param helpTitle 气泡标题
+ * @param helpText 气泡正文
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ParamLabelWithHelp(
+    label: String,
+    helpTitle: String,
+    helpText: String
+) {
+    val tooltipState = rememberTooltipState(isPersistent = true)
+    val scope = rememberCoroutineScope()
+
+    // 气泡是独立 Popup 窗口，不随页面动画走。不在这里吃掉返回，侧滑就会被
+    // SettingsScreen 的 BackHandler 抢去翻页，气泡则悬在新页面上再消失。
+    BackHandler(enabled = tooltipState.isVisible) { tooltipState.dismiss() }
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                TooltipAnchorPosition.Below
+            ),
+            tooltip = {
+                RichTooltip(
+                    title = { Text(helpTitle) },
+                    action = {
+                        TextButton(onClick = { tooltipState.dismiss() }) { Text("知道了") }
+                    }
+                ) {
+                    Text(helpText)
+                }
+            },
+            state = tooltipState,
+            enableUserInput = false
+        ) {
+            IconButton(
+                onClick = { scope.launch { tooltipState.show() } },
+                modifier = Modifier.size(28.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_help_outline),
+                    contentDescription = "$helpTitle 说明",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = ALPHA_FAINT_TEXT),
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+    }
+}
 
 /**
  * 设置卡片：圆角半透明 Surface 容器，可选组标题。

--- a/app/src/main/res/drawable/ic_help_outline.xml
+++ b/app/src/main/res/drawable/ic_help_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11 18h2v-2h-2zm1-16A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8m0-14a4 4 0 0 0-4 4h2a2 2 0 0 1 2-2a2 2 0 0 1 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5a4 4 0 0 0-4-4" />
+</vector>

--- a/tools/icons.txt
+++ b/tools/icons.txt
@@ -57,3 +57,6 @@ mdi/lock-open-variant-outline   ic_overlay_unlock
 # ── 悬浮窗输入框（OverlayInputWindow）──
 mdi/send                        ic_send
 mdi/drag-vertical               ic_drag
+
+# ── 参数说明帮助图标（ProviderSettings）──
+mdi/help-circle-outline         ic_help_outline


### PR DESCRIPTION
Add:
- Temperature滑杆标签旁增加问号图标，点击弹出RichTooltip 讲解该参数： 作用、桌宠场景的建议取值，以及「设为0不保证输出一致、部分提供商上限 为1.0、推理模型会忽略此参数」三条注意事项
- SettingsCommon增加通用组件 ParamLabelWithHelp（参数标签 + 说明气泡）， 其余参数滑杆可直接复用
- 图标ic_help_outline（MDI help-circle-outline，Apache 2.0，516 字节），经tools/svg2vd.py生成，清单同步至tools/icons.txt。未复用 information-outline 以便与ic_settings_about区分

Fix:
- 调试中发现，说明对话框开启时侧滑返回会把其拖到上一页面再突然消失。对话框是TooltipBox起的独立窗口，不在AnimatedContent内，因此不参与页面切换动画； 而返回被SettingsScreen的BackHandler抢去翻页，对话框便悬在新页面上直到recomposition才消失。改为对话框可见时以更内层的BackHandler吃掉返回并收起对话框，符合返回先关最上层临时UI的惯例

Update:
- 记忆对话框的「清除全部」改为红色，条目为空时变灰
- 主界面「更多」菜单的「清除对话」改为红色，同上
- 说明气泡的positionProvider用 rememberTooltipPositionProvider (TooltipAnchorPosition.Below)：rememberRichTooltipPositionProvider与无参的rememberTooltipPositionProvider在Material3 1.4.0均已弃用