### PR TITLE
 fix: 气泡寿命反向延长+网关错误可见性+多处缺失护栏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **滑动窗口裁剪打乱消息原始顺序（#3）** — `ConversationManager.trimWindow` 原用「system 整体提前 + 非 system 尾部拼接」重建列表，把 system 消息全部挪到最前，打乱与 user/assistant 的交错顺序。改为就地迭代器从头部逐条裁掉最旧的超额非 system 消息，保留原始交错顺序。
 - **Markwon 缓存键不含全部构造参数（#5）** — `MarkdownText` 的 `markwonCache` 键仅 `dark: Boolean`，但 `textSizePx` 参与构造；系统字体缩放/显示密度变化时同 dark 命中旧实例，公式字号错乱。缓存键改为含全部构造参数的 `MarkwonKey(dark, textSizePx, tableBorder)`，调用处 `remember` 键同步。
 - **modelIds 吞 CancellationException（#2 / #46）** — `ApiResponse.modelIds` 原用裸 `catch (_: Exception)`，违反项目 `ErrorHandling.kt` 的取消重抛约定。现前置 `catch (e: CancellationException) { throw e }`，普通异常记 `Log.w` 后返回空列表，与同文件 `chatCompletionContent` 的 `runCatchingLog` 风格统一。
+- **系统气泡「挤旧扣寿命」实际会延长寿命** — `SystemBubblePolicy` 原按「剩余时长」运算，`ChatViewModel` 扣减后取消旧 Job 并从当前时刻重新 `delay(newLife)`，已流逝的时间被丢弃：一个已存活 6 秒的气泡「扣 2 秒」变成再活 5 秒（总计 11 秒），比原定 7 秒更久，与「挤旧」意图相反。策略函数改为按**绝对到期时刻**运算（`computeNextDeadline(deadlineMs, nowMs, reduceCount, position)`），`lifeMap` 值类型由 `Triple<Long, Job, Int>` 换成语义明确的 `BubbleLife(deadlineMs, job, reduceCount)`，时间基准取 `SystemClock.elapsedRealtime()`；剩余不足一个扣减步长时钳到当前时刻立即移除。排位阈值 3 提取为 `KEEP_FULL_LIFE_POSITIONS`。补 3 条回归用例（含「任意时刻扣减都不会让到期时刻推后」的遍历断言）。
+- **API 网关错误详情被完全丢弃** — `ApiException` 存了 `responseBody` 却无任何读取点：用户只看到「请求过于频繁」这类状态码文案，Logcat 里也没有原始响应体，无从判断是哪个模型、哪条限额触发。新增 `ApiResponse.errorMessage(body)` 解析网关错误说明（兼容 `error.message` 对象、`error` 字符串、顶层 `message` 三种形态），`ApiException.friendlyMessage(statusCode, detail)` 把它拼进用户可见文案（截断至 200 字符），原始响应体经 `Log.w` 落 Logcat 供导出日志排查。
+- **等悬浮窗停止的 GL 恢复轮询无超时上限** — `MainActivity.onResume` 原用 `Handler.postDelayed(16L)` 轮询 `Live2dRenderState.isRunning`，Service 若异常退出、没能把 `isRunning` 置回 false，轮询永不终止且 `glSurfaceView.onResume()` 永不执行 → 主界面永久黑屏 + 每 16ms 唤醒主线程。改为 `lifecycleScope` 内订阅 StateFlow（`isRunning.first { !it }`）并加 2 秒 `withTimeoutOrNull` 上限，超时记 `Log.w` 后照常恢复 GL；随之删掉专用的 `mainHandler` 与 `resumeGate`。
+- **LogExporter 的 waitFor() 无超时** — `logcat -d` 子进程异常挂起时 `process.waitFor()` 会无限占住 `Dispatchers.IO` 线程且不响应协程取消。改为 `waitFor(5, TimeUnit.SECONDS)`，超时记 `Log.w` 并 `destroyForcibly()` 兜底。
+- **TTS attn 矩阵护栏形同虚设** — `DurationExpander.MAX_TOTAL_FRAMES = 480_000` 在上游 200 字截断（`TtsManager.MAX_SYNTH_CHARS`）下永远触发不到（最坏 50 帧/音素 × 约 3600 音素 ≈ 180000 帧），等于没有护栏；注释「约等于 22 秒音频」也算错约 250 倍（实为约 93 分钟）。改为按 attn 矩阵内存封顶（`MAX_ATTENTION_BYTES = 64MiB`，上限随 `tX` 动态换算成帧数），真正拦住 dp 输出异常、逐音素全被钳满那条原可膨胀到 GB 量级的路径；正常语音（200 字、语速 0.5~2.0）对应上限约 9300 帧 ≈ 108 秒，不会被截。
+- **重试目标已不在历史时会误删全部 assistant 回复** — `ChatService.retryLastMessage` 的 `lastUserMessage()` 与 `getMessages()` 是两次独立加锁，之间该消息若被移除，`indexOfLast` 返回 -1 使 `drop(userIdx + 1)` 退化为 `drop(0)`，随后的 assistant 过滤会删掉整段历史的助手消息。补 `userIdx < 0` 前置判断，直接返回失败。
+
+### Documentation
+
+- **修正 ConversationManager 的自相矛盾文档** — 类注释原称「不关心消息是用户还是助手发送的，仅按顺序维护」，但 `trimWindow` 豁免 system、`buildApiMessages` 重组 system 前缀、并提供 `lastUserMessage`/`lastAssistantMessage` 按角色查询，实际处处关心角色；改为如实说明。另 `lastUserMessage()` 的 KDoc 写「最后一条非 system 消息」而实现只取 `role == user`（非 system 还包含 assistant），一并修正。
 
 ### Performance
 
@@ -29,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 
-- 本次修复对应 `code-review-triage.md` 的 P0 全部 5 项（#3/#4/#5/#7 + #2/#46），并顺手修复 #39/#40、为 #1 的 `lifeMap` 补充线程约束注释（说明其安全性依赖 `Dispatchers.Main.immediate` 单线程前提）。P1 稳定性（ANR 风险）与架构重构另行排期。
+- 首批修复对应 `code-review-triage.md` 的 P0 全部 5 项（#3/#4/#5/#7 + #2/#46），并顺手修复 #39/#40、为 #1 的 `lifeMap` 补充线程约束注释（说明其安全性依赖 `Dispatchers.Main.immediate` 单线程前提）。
+- 第二批（本次）是对 48 条审查结论独立复核后的第一档「小改动高收益」项：一条报告未发现的真实逻辑 bug（系统气泡寿命）、#18 网关错误详情、#38 waitFor 超时，以及三处报告未提到的护栏/边界缺失（GL 恢复轮询无超时、TTS attn 护栏失效、重试边界）。复核同时认定 #6（条件分支内 `collectAsState`）为合法 Compose 用法、#44（`ensureDict` 竞态）因底层 `PinyinDict.init` 已 `@Synchronized` 幂等而无实际危害，两者不再列为待修。
+- P1 稳定性（#37 `currentPrefs` 主线程 `runBlocking`、#15 隐私授权双存储）与架构重构（#8~#14/#16/#19）另行排期。
 
 ---
 

--- a/app/src/main/java/com/meapet/mobile/chat/ChatService.kt
+++ b/app/src/main/java/com/meapet/mobile/chat/ChatService.kt
@@ -169,6 +169,13 @@ class ChatService(
         // 重发时由 sendMessage 统一重新入史，避免消息重复
         val history = conversationManager.getMessages()
         val userIdx = history.indexOfLast { it.id == lastUserMsg.id }
+        // lastUserMessage() 与 getMessages() 是两次独立加锁，之间该消息若被移除
+        // （清空会话 / 窗口裁剪），userIdx 会是 -1，drop(0) 就等于「整个历史」，
+        // 会把历史里所有 assistant 回复一并误删。
+        if (userIdx < 0) {
+            Log.w(TAG, "Retry target no longer in history, aborting")
+            return Result.failure(IllegalStateException("该消息已不在会话历史中，无法重试"))
+        }
         history.drop(userIdx + 1)
             .filter { it.role == ChatRole.assistant }
             .forEach { conversationManager.removeMessage(it.id) }

--- a/app/src/main/java/com/meapet/mobile/chat/ConversationManager.kt
+++ b/app/src/main/java/com/meapet/mobile/chat/ConversationManager.kt
@@ -13,7 +13,9 @@ import android.util.Log
  *
  * ## 低耦合
  * - 内存操作 + 可选的存储回调，不依赖其他业务模块；
- * - 不关心消息是用户还是助手发送的，仅按顺序维护。
+ * - 但**确实关心消息角色**：system 消息不参与窗口裁剪（见 [trimWindow]）、
+ *   也不进 API 历史（[buildApiMessages] 自行重组 system 前缀），
+ *   并提供 [lastUserMessage] / [lastAssistantMessage] 按角色查询。
  *
  * ## 线程安全
  * 启动时 [restore] 在 IO 线程执行，可能与发送链路并发访问，
@@ -139,7 +141,7 @@ class ConversationManager(
         removed
     }
 
-    /** 获取最后一条非 system 消息。 */
+    /** 获取最后一条 user 消息（不含 assistant / system）。 */
     fun lastUserMessage(): ChatMessage? = synchronized(lock) {
         messages.lastOrNull { it.role == ChatRole.user }
     }

--- a/app/src/main/java/com/meapet/mobile/chat/SystemBubblePolicy.kt
+++ b/app/src/main/java/com/meapet/mobile/chat/SystemBubblePolicy.kt
@@ -5,10 +5,16 @@ package com.meapet.mobile.chat
  *
  * 纯逻辑、无协程/UI 依赖，便于单元测试。规则：
  * - 每个气泡初始寿命 [BASE_LIFE_MS]（7 秒）；
- * - 每次有新气泡加入、按 timestamp 重新排位后，位置靠后的气泡被「挤旧」，
- *   剩余寿命按 [REDUCE_STEP_MS]（2 秒）扣减，**累计最多扣 [MAX_REDUCE_COUNT]
- *   （2 次，共 4 秒）**，寿命下限 [MIN_LIFE_MS]（3 秒）——保证旧气泡不会
- *   因新气泡持续到来而被无限挤压至 0。
+ * - 每次有新气泡加入、按 timestamp 重新排位后，排在 [KEEP_FULL_LIFE_POSITIONS] 之后的气泡
+ *   被「挤旧」，**剩余**寿命按 [REDUCE_STEP_MS]（2 秒）扣减，累计最多扣 [MAX_REDUCE_COUNT]
+ *   （2 次，共 4 秒）——因此单个气泡从产生到消失至少存活 [MIN_LIFE_MS]（3 秒），
+ *   不会因新气泡持续到来而被无限挤压。
+ *
+ * ## 为什么用「到期时刻」而不是「剩余时长」
+ * 扣减必须作用在**剩余**寿命上。若只记时长、扣减后从当前时刻重新倒计时，已流逝的时间
+ * 就被丢掉了：一个已存活 6 秒的气泡「扣 2 秒」会变成再活 5 秒（总计 11 秒），
+ * 比原定 7 秒更久，与「挤旧」的意图完全相反。所以本策略统一按**绝对到期时刻**运算，
+ * 调用方只需保证 `nowMs` 与 `deadlineMs` 出自同一单调时间基准。
  */
 object SystemBubblePolicy {
 
@@ -18,32 +24,35 @@ object SystemBubblePolicy {
     /** 位置靠后时每次扣减的寿命（ms）。 */
     const val REDUCE_STEP_MS = 2_000L
 
+    /** 前若干位（最新）保持满寿命，不参与扣减。 */
+    const val KEEP_FULL_LIFE_POSITIONS = 3
+
     /** 单个气泡最多被扣减的次数（7 秒 - 2×2 秒 = 3 秒保底）。 */
     const val MAX_REDUCE_COUNT = 2
 
-    /** 气泡寿命下限（ms）。 */
+    /** 气泡寿命下限（ms）：由扣减次数上限自然保证。 */
     const val MIN_LIFE_MS = BASE_LIFE_MS - MAX_REDUCE_COUNT * REDUCE_STEP_MS
 
     /**
-     * 按当前排位计算气泡的下一个剩余寿命。
+     * 按当前排位计算气泡的下一个到期时刻。
      *
-     * @param currentLifeMs 当前剩余寿命
+     * @param deadlineMs 当前到期时刻（与 [nowMs] 同一时间基准）
+     * @param nowMs 当前时刻
      * @param reduceCount 本气泡已扣减次数（0 起步，上限 [MAX_REDUCE_COUNT]）
      * @param position 当前排位（1 = 最新，按 timestamp 降序）
-     * @return Pair(新剩余寿命, 新的扣减次数)
+     * @return Pair(新到期时刻, 新的扣减次数)；不需要扣减时原样返回入参
      */
-    fun computeNextLife(
-        currentLifeMs: Long,
+    fun computeNextDeadline(
+        deadlineMs: Long,
+        nowMs: Long,
         reduceCount: Int,
         position: Int
     ): Pair<Long, Int> {
-        var life = currentLifeMs
-        var count = reduceCount
-        // 位置被挤到 4 位及以后 且 还有扣减配额 时扣 2 秒
-        if (position > 3 && count < MAX_REDUCE_COUNT) {
-            life = (life - REDUCE_STEP_MS).coerceAtLeast(MIN_LIFE_MS)
-            count++
+        if (position <= KEEP_FULL_LIFE_POSITIONS || reduceCount >= MAX_REDUCE_COUNT) {
+            return deadlineMs to reduceCount
         }
-        return life to count
+        // 扣剩余寿命；已不足一个扣减步长时钳到当前时刻（下一次调度即移除），不允许倒退到过去
+        val reduced = (deadlineMs - REDUCE_STEP_MS).coerceAtLeast(nowMs)
+        return reduced to reduceCount + 1
     }
 }

--- a/app/src/main/java/com/meapet/mobile/client/OpenAiCompatibleClient.kt
+++ b/app/src/main/java/com/meapet/mobile/client/OpenAiCompatibleClient.kt
@@ -1,6 +1,8 @@
 package com.meapet.mobile.client
 
+import android.util.Log
 import com.meapet.mobile.client.exception.ApiException
+import com.meapet.mobile.client.model.ApiResponse
 
 /**
  * OpenAI 兼容 HTTP 客户端。
@@ -88,6 +90,8 @@ class OpenAiCompatibleClient(
     }
 
     companion object {
+        private const val TAG = "OpenAiCompatibleClient"
+
         /**
          * 把用户填写的地址规范成 API 根：去空白、去尾部 `/`，其余原样保留。
          *
@@ -123,11 +127,18 @@ class OpenAiCompatibleClient(
     private suspend fun executeExpectOk(request: HttpRequest): HttpResponse {
         val response = engine.execute(request)
         if (response.statusCode !in 200..299) {
-            // 用面向用户的友好文案（401 → 提示填写 API Key）
+            val body = response.bodyAsText()
+            // 原始响应体只进日志：排查时必须有它（此前既不进 UI 也不进日志，
+            // 用户只看到「请求过于频繁」而无从判断真因），但可能含冗长的网关堆栈
+            Log.w(TAG, "HTTP ${response.statusCode} on ${request.url}: $body")
+            // 面向用户的友好文案 + 网关给出的具体原因
             throw ApiException(
                 statusCode = response.statusCode,
-                responseBody = response.bodyAsText(),
-                message = ApiException.friendlyMessage(response.statusCode)
+                responseBody = body,
+                message = ApiException.friendlyMessage(
+                    response.statusCode,
+                    ApiResponse.errorMessage(body)
+                )
             )
         }
         return response

--- a/app/src/main/java/com/meapet/mobile/client/exception/ApiException.kt
+++ b/app/src/main/java/com/meapet/mobile/client/exception/ApiException.kt
@@ -13,6 +13,9 @@ class ApiException(
 ) : RuntimeException(message) {
 
     companion object {
+        /** 拼进用户可见文案的网关错误说明最大长度（超出截断，避免错误卡片被长堆栈撑爆）。 */
+        private const val MAX_DETAIL_LENGTH = 200
+
         /** 常见状态码的面向用户友好提示。 */
         fun friendlyMessage(statusCode: Int): String = when (statusCode) {
             401 -> "API Key 无效或未填写，请在设置中填写正确的 API Key"
@@ -21,6 +24,26 @@ class ApiException(
             404 -> "接口地址不存在，请检查 API 地址是否填写正确"
             429 -> "请求过于频繁，请稍后再试"
             else -> "API 请求失败（HTTP $statusCode）"
+        }
+
+        /**
+         * 状态码友好提示 + 网关给出的具体原因。
+         *
+         * 只给状态码文案时，用户看到的永远是「请求过于频繁」这类笼统说法，
+         * 无从判断是哪个模型、哪条限额触发的；把网关的 `error.message`
+         * 拼进来才有排查价值（原始响应体仍只进日志，不进 UI）。
+         *
+         * @param detail 网关错误说明，通常来自 [com.meapet.mobile.client.model.ApiResponse.errorMessage]
+         */
+        fun friendlyMessage(statusCode: Int, detail: String?): String {
+            val base = friendlyMessage(statusCode)
+            val trimmed = detail?.trim()?.takeIf { it.isNotEmpty() } ?: return base
+            val shown = if (trimmed.length > MAX_DETAIL_LENGTH) {
+                trimmed.take(MAX_DETAIL_LENGTH) + "…"
+            } else {
+                trimmed
+            }
+            return "$base\n（服务端返回：$shown）"
         }
     }
 }

--- a/app/src/main/java/com/meapet/mobile/client/model/ApiResponse.kt
+++ b/app/src/main/java/com/meapet/mobile/client/model/ApiResponse.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -59,5 +60,31 @@ object ApiResponse {
     } catch (e: Exception) {
         Log.w(TAG, "Failed to parse model ids: ${e.message}")
         emptyList()
+    }
+
+    /**
+     * 从错误响应体里提取网关给出的具体错误说明。
+     *
+     * 兼容三种常见形态：
+     * - `{"error":{"message":"Rate limit exceeded for model X"}}`（OpenAI 及多数兼容网关）
+     * - `{"error":"invalid key"}`（部分自建代理直接给字符串）
+     * - `{"message":"…"}`（少数网关不套 error）
+     *
+     * @return 去空白后的错误说明；结构不符、字段缺失或为空时返回 null
+     */
+    fun errorMessage(body: String): String? = try {
+        val root = json.parseToJsonElement(body) as? JsonObject
+        val detail = when (val err = root?.get("error")) {
+            is JsonObject -> err["message"]?.jsonPrimitive?.contentOrNull
+            is JsonPrimitive -> err.contentOrNull
+            else -> null
+        } ?: root?.get("message")?.jsonPrimitive?.contentOrNull
+        detail?.trim()?.takeIf { it.isNotEmpty() }
+    } catch (e: CancellationException) {
+        // 取消一律重抛（见 ErrorHandling.kt 约定），不能吞
+        throw e
+    } catch (e: Exception) {
+        // 错误体本身解析失败不值得再报错，调用方退回纯状态码文案即可
+        null
     }
 }

--- a/app/src/main/java/com/meapet/mobile/core/LogExporter.kt
+++ b/app/src/main/java/com/meapet/mobile/core/LogExporter.kt
@@ -16,6 +16,7 @@ import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 /**
  * 日志导出：抓取 logcat + 本进程 native crash tombstone，写入 cache，拉起系统分享菜单。
@@ -37,6 +38,9 @@ object LogExporter {
 
     private const val TAG = "LogExporter"
     private const val LOG_DIR = "logs"
+
+    /** 等 logcat 子进程退出的上限（秒）：正常瞬间返回，超时即强杀，不允许无上限阻塞。 */
+    private const val LOGCAT_WAIT_TIMEOUT_SECONDS = 5L
 
     /**
      * 导出日志并拉起系统分享菜单。
@@ -146,7 +150,12 @@ object LogExporter {
             val process = ProcessBuilder("logcat", "-d", "-v", "threadtime")
                 .redirectErrorStream(true).start()
             process.inputStream.use { it.copyTo(out) }
-            process.waitFor()
+            // waitFor() 不带超时会把所在 Dispatchers.IO 线程占死，而且不响应协程取消：
+            // logcat -d 正常会在输出读完后立刻退出，只有异常挂起时才需要强杀兜底。
+            if (!process.waitFor(LOGCAT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                Log.w(TAG, "logcat 子进程 ${LOGCAT_WAIT_TIMEOUT_SECONDS}s 未退出，强制结束")
+                process.destroyForcibly()
+            }
         } catch (e: Exception) {
             out.writeLine("（logcat 抓取失败: ${e.message}）")
         }

--- a/app/src/main/java/com/meapet/mobile/tts/DurationExpander.kt
+++ b/app/src/main/java/com/meapet/mobile/tts/DurationExpander.kt
@@ -22,10 +22,21 @@ object DurationExpander {
     private const val MAX_FRAMES_PER_PHONE = 50
 
     /**
-     * 整段音频总帧数上限（yLengths）。超出时截断对齐路径，防止 attn 矩阵
-     * （yLengths × tX 个 Float）膨胀到 OOM。约等于 22 秒音频。
+     * attn 矩阵（yLengths × tX 个 Float）的内存上限，超出即截断对齐路径。
+     *
+     * 按内存封顶而非固定帧数：原先的 `MAX_TOTAL_FRAMES = 480_000` 在上游 200 字截断
+     * （`TtsManager.MAX_SYNTH_CHARS`）下永远触发不到——最坏是逐音素全被钳到
+     * [MAX_FRAMES_PER_PHONE]，50 × 约 3600 音素 ≈ 180000 帧 < 480000，等于没有护栏；
+     * 那条注释「约等于 22 秒音频」也算错了：480000 帧 × 256 采样 / 22050Hz ≈ 93 分钟。
+     *
+     * 而它真正要拦的就是 dp 输出异常、逐音素全被钳满的那条路径（此时音频本就是废的，
+     * 早截无损失，旧值下 attn 可达 2GB 量级）。按内存封顶与文本长度无关：
+     * 正常语音（200 字、语速 0.5~2.0，tX 约 1800）对应上限约 9300 帧 ≈ 108 秒，不会被截。
      */
-    const val MAX_TOTAL_FRAMES = 480_000
+    private const val MAX_ATTENTION_BYTES = 64L * 1024 * 1024
+
+    /** attn 元素类型为 Float。 */
+    private const val BYTES_PER_FLOAT = 4L
 
     /**
      * 步骤 3：时长展开 + 注意力路径。
@@ -64,12 +75,15 @@ object DurationExpander {
             }
         }
 
-        // 累加总帧数，超上限即截断（防 attn 矩阵 OOM）
+        // 累加总帧数，按 attn 矩阵内存上限截断（防 OOM，见 MAX_ATTENTION_BYTES）
+        val maxFrames = (MAX_ATTENTION_BYTES / (tX.coerceAtLeast(1) * BYTES_PER_FLOAT))
+            .coerceAtLeast(1L)
+            .toInt()
         var yLengths = 0
         for (v in wCeil) {
             yLengths += v
-            if (yLengths >= MAX_TOTAL_FRAMES) {
-                yLengths = MAX_TOTAL_FRAMES
+            if (yLengths >= maxFrames) {
+                yLengths = maxFrames
                 break
             }
         }

--- a/app/src/main/java/com/meapet/mobile/ui/MainActivity.kt
+++ b/app/src/main/java/com/meapet/mobile/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.lifecycle.lifecycleScope
 import com.meapet.mobile.BuildConfig
 import com.meapet.mobile.core.PrivacyConsentManager
 import com.meapet.mobile.core.isDarkTheme
@@ -39,7 +40,10 @@ import com.meapet.mobile.ui.component.AutoUpdateOptInDialog
 import com.meapet.mobile.ui.component.PRIVACY_POLICY_VERSION
 import com.meapet.mobile.ui.screen.ChatScreenContent
 import com.meapet.mobile.ui.theme.MeaPetTheme
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * 主入口 Activity。
@@ -56,14 +60,16 @@ class MainActivity : ComponentActivity() {
     private lateinit var container: AppContainer
     private var insetsController: WindowInsetsControllerCompat? = null
 
-    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
-    /** 等待悬浮窗 Service 完全停止后再恢复本 Activity GL 渲染的轮询任务。 */
-    private var resumeGate: Runnable? = null
+    /** 等待悬浮窗 Service 完全停止后再恢复本 Activity GL 渲染的订阅任务。 */
+    private var resumeJob: Job? = null
 
     companion object {
         private const val TAG = "MainActivity"
         private const val OVERLAY_PERMISSION_REQUEST = 1001
         private const val NOTIFICATION_PERMISSION_REQUEST = 1002
+
+        /** 等悬浮窗 Service 停止的上限：超时则照常恢复 GL，不允许无上限等待。 */
+        private const val GL_RESUME_WAIT_TIMEOUT_MS = 2_000L
     }
 
     // ── 生命周期 ──────────────────────────────────────
@@ -274,22 +280,27 @@ class MainActivity : ComponentActivity() {
         // CubismShaderAndroid 单例（Service 侧曾在其上下文里重建过 shader），
         // 导致本 Activity 用到无效 program → 黑屏/GL 报错。
         // 因此等 Service 完全停止（isRunning=false）后再恢复渲染。
-        resumeGate?.let { mainHandler.removeCallbacks(it) }
+        resumeJob?.cancel()
+        resumeJob = null
         if (Live2dRenderState.isRunning.value) {
-            val gate = object : Runnable {
-                override fun run() {
-                    if (Live2dRenderState.isRunning.value) {
-                        mainHandler.postDelayed(this, 16L)
-                    } else {
-                        resumeGate = null
-                        try { glSurfaceView.onResume() } catch (e: Exception) {
-                            Log.e(TAG, "onResume(gated) error: ${e.message}")
-                        }
-                    }
+            resumeJob = lifecycleScope.launch {
+                // 订阅 StateFlow 而非轮询；必须带超时上限：Service 若异常退出、
+                // 没能把 isRunning 置回 false，无上限等待会让 GL 永不恢复（主界面永久黑屏）。
+                // 超时后照常恢复——宁可冒一次 shader 竞争，也不能把界面卡死。
+                val stopped = withTimeoutOrNull(GL_RESUME_WAIT_TIMEOUT_MS) {
+                    Live2dRenderState.isRunning.first { !it }
+                    true
+                } == true
+                if (!stopped) {
+                    Log.w(TAG, "Overlay service still running after ${GL_RESUME_WAIT_TIMEOUT_MS}ms, resuming GL anyway")
+                }
+                resumeJob = null
+                try {
+                    glSurfaceView.onResume()
+                } catch (e: Exception) {
+                    Log.e(TAG, "onResume(gated) error: ${e.message}")
                 }
             }
-            resumeGate = gate
-            mainHandler.post(gate)
         } else {
             try {
                 glSurfaceView.onResume()
@@ -301,9 +312,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onPause() {
         super.onPause()
-        // 取消等待 Service 停止的轮询，避免 Activity 已 pause 后还去 onResume GL
-        resumeGate?.let { mainHandler.removeCallbacks(it) }
-        resumeGate = null
+        // 取消等待 Service 停止的订阅，避免 Activity 已 pause 后还去 onResume GL
+        resumeJob?.cancel()
+        resumeJob = null
         try {
             glSurfaceView.onPause()
         } catch (e: Exception) {

--- a/app/src/main/java/com/meapet/mobile/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/meapet/mobile/viewmodel/ChatViewModel.kt
@@ -1,6 +1,7 @@
 package com.meapet.mobile.viewmodel
 
 import android.app.Application
+import android.os.SystemClock
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.meapet.mobile.chat.ChatMessage
@@ -24,6 +25,20 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+
+/**
+ * 单条系统气泡的生命周期状态。
+ *
+ * @property deadlineMs 到期移除时刻（[SystemClock.elapsedRealtime] 基准，单调不受改表影响）
+ * @property job 到期移除任务
+ * @property reduceCount 已被「挤旧」扣减的次数（上限 [SystemBubblePolicy.MAX_REDUCE_COUNT]）
+ */
+private data class BubbleLife(
+    val deadlineMs: Long,
+    val job: Job,
+    val reduceCount: Int
+)
 
 /**
  * 聊天界面 ViewModel。
@@ -73,25 +88,28 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
 
         // 监听 Live2D 触摸分区事件→添加系统消息气泡
         // 每条气泡独立生命周期，从产生开始倒计时 7 秒。
-        // 新消息到达时按位置自动扣除旧气泡的剩余寿命：
+        // 新消息到达时按位置扣除旧气泡的剩余寿命（扣的是「还剩多久」，不是重新计时）：
         //   position 1-3（最新）→ 不扣
         //   position 4-5          → 扣 2 秒
         //   position 6+（最旧）→ 扣 4 秒（首次扣 2 秒 + 再次扣 2 秒）
         viewModelScope.launch {
-            // msgId → (剩余毫秒, 移除Job, 已扣减次数)
+            // msgId → 气泡生命周期（到期时刻 / 移除Job / 已扣减次数）
             // 线程约束：lifeMap 无同步，安全性依赖「所有读写都经 viewModelScope.launch
             // 运行在 Dispatchers.Main.immediate 单线程上」这一前提（collect 协程写、
             // scheduleRemove 协程删）。若未来把任一访问挪到别的调度器，必须改用
             // Mutex / actor 保护，否则会并发修改非线程安全 Map。
-            val lifeMap = LinkedHashMap<String, Triple<Long, Job, Int>>()
+            val lifeMap = LinkedHashMap<String, BubbleLife>()
 
             Live2dManager.tapMessageEvent.collect { text ->
                 val newMsg = ChatMessage(role = ChatRole.system, content = text)
                 _state.update { it.copy(messages = it.messages + newMsg) }
 
+                // 本轮统一取一次「现在」，保证新气泡定寿命与旧气泡扣寿命同基准
+                val now = SystemClock.elapsedRealtime()
+
                 // 为本条启动独立倒计时，初始寿命见 SystemBubblePolicy
                 val job = scheduleRemove(lifeMap, newMsg.id, SystemBubblePolicy.BASE_LIFE_MS)
-                lifeMap[newMsg.id] = Triple(SystemBubblePolicy.BASE_LIFE_MS, job, 0)
+                lifeMap[newMsg.id] = BubbleLife(now + SystemBubblePolicy.BASE_LIFE_MS, job, 0)
 
                 // 重新排位：按 timestamp 降序（最新在前），重新分配剩余寿命
                 val sysIds = _state.value.messages
@@ -102,16 +120,19 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                 sysIds.forEachIndexed { index, id ->
                     val position = index + 1 // 1 = 最新
                     val entry = lifeMap[id] ?: return@forEachIndexed
-                    val (currentLife, oldJob, reduceCount) = entry
 
-                    // 按排位扣减寿命（策略见 SystemBubblePolicy）
-                    val (newLife, newCount) =
-                        SystemBubblePolicy.computeNextLife(currentLife, reduceCount, position)
+                    // 按排位扣减剩余寿命（策略见 SystemBubblePolicy）
+                    val (newDeadline, newCount) = SystemBubblePolicy.computeNextDeadline(
+                        deadlineMs = entry.deadlineMs,
+                        nowMs = now,
+                        reduceCount = entry.reduceCount,
+                        position = position
+                    )
 
-                    if (newLife != currentLife) {
-                        oldJob.cancel()
-                        val newJob = scheduleRemove(lifeMap, id, newLife)
-                        lifeMap[id] = Triple(newLife, newJob, newCount)
+                    if (newDeadline != entry.deadlineMs) {
+                        entry.job.cancel()
+                        val newJob = scheduleRemove(lifeMap, id, newDeadline - now)
+                        lifeMap[id] = BubbleLife(newDeadline, newJob, newCount)
                     }
                 }
             }
@@ -395,21 +416,19 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
 
     /**
      * 调度系统气泡的延时移除，返回对应的 Job。
-     * @param lifeMap 更新此 map 中的条目
+     * @param lifeMap 到期后从此 map 中摘掉对应条目
      * @param msgId 消息 ID
-     * @param delayMs 剩余毫秒数
+     * @param delayMs 距到期还有多少毫秒（≤0 表示立即到期）
      */
     private fun scheduleRemove(
-        lifeMap: MutableMap<String, Triple<Long, Job, Int>>,
+        lifeMap: MutableMap<String, BubbleLife>,
         msgId: String,
         delayMs: Long
     ): Job = viewModelScope.launch {
-        if (delayMs <= 0) {
-            removeBubble(msgId)
-            lifeMap.remove(msgId)
-            return@launch
-        }
-        kotlinx.coroutines.delay(delayMs.milliseconds)
+        // 必须先让出一次再动 lifeMap：viewModelScope 用 Dispatchers.Main.immediate，
+        // delay(0) 不会挂起，协程体会同步跑在调用方写回 lifeMap 之前，
+        // 于是刚被摘掉的条目又被写回去，留下持有已完成 Job 的僵尸条目。
+        if (delayMs > 0) kotlinx.coroutines.delay(delayMs.milliseconds) else yield()
         removeBubble(msgId)
         lifeMap.remove(msgId)
     }

--- a/app/src/test/java/com/meapet/mobile/chat/SystemBubblePolicyTest.kt
+++ b/app/src/test/java/com/meapet/mobile/chat/SystemBubblePolicyTest.kt
@@ -1,6 +1,7 @@
 package com.meapet.mobile.chat
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -8,99 +9,153 @@ import org.junit.Test
  *
  * 覆盖规则：
  * - 位置 1-3（最新）不扣寿命；
- * - 位置 4 及以后被挤旧时扣 2 秒，**累计最多扣 [SystemBubblePolicy.MAX_REDUCE_COUNT]
- *   （2 次，共 4 秒）**，寿命封底 [SystemBubblePolicy.MIN_LIFE_MS]（3 秒）；
- * - 已扣满上限后即使持续停留在旧位也不再下降。
+ * - 位置 4 及以后被挤旧时从**剩余**寿命里扣 2 秒，累计最多扣
+ *   [SystemBubblePolicy.MAX_REDUCE_COUNT]（2 次，共 4 秒）；
+ * - 已扣满上限后即使持续停留在旧位也不再下降；
+ * - 扣减永不把总寿命拉长（回归用例：扣减必须作用在剩余寿命上，不能重新计时）。
  */
 @Suppress("NonAsciiCharacters")
 class SystemBubblePolicyTest {
 
+    /** 气泡产生时刻，仅作为可读的时间基准原点。 */
+    private val born = 1_000_000L
+
+    /** 刚产生的气泡的到期时刻。 */
+    private val baseDeadline = born + SystemBubblePolicy.BASE_LIFE_MS
+
     @Test
     fun `位置 1 到 3 不扣寿命且不增加计数`() {
         for (position in 1..3) {
-            val (life, count) = SystemBubblePolicy.computeNextLife(
-                SystemBubblePolicy.BASE_LIFE_MS, reduceCount = 0, position = position
+            val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+                deadlineMs = baseDeadline,
+                nowMs = born,
+                reduceCount = 0,
+                position = position
             )
-            assertEquals("position=$position 不应扣寿命", SystemBubblePolicy.BASE_LIFE_MS, life)
+            assertEquals("position=$position 不应扣寿命", baseDeadline, deadline)
             assertEquals("position=$position 不应增加计数", 0, count)
         }
     }
 
     @Test
     fun `位置 4 首次扣 2 秒`() {
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            SystemBubblePolicy.BASE_LIFE_MS, reduceCount = 0, position = 4
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline,
+            nowMs = born,
+            reduceCount = 0,
+            position = 4
         )
-        assertEquals(5_000L, life)
+        assertEquals(baseDeadline - 2_000L, deadline)
         assertEquals(1, count)
     }
 
     @Test
     fun `位置 6 首次同样扣 2 秒`() {
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            SystemBubblePolicy.BASE_LIFE_MS, reduceCount = 0, position = 6
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline,
+            nowMs = born,
+            reduceCount = 0,
+            position = 6
         )
-        assertEquals(5_000L, life)
+        assertEquals(baseDeadline - 2_000L, deadline)
         assertEquals(1, count)
     }
 
     @Test
     fun `位置 6 第二次扣 2 秒`() {
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            currentLifeMs = 5_000L, reduceCount = 1, position = 6
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline - 2_000L,
+            nowMs = born,
+            reduceCount = 1,
+            position = 6
         )
-        assertEquals(3_000L, life)
+        assertEquals(baseDeadline - 4_000L, deadline)
         assertEquals(2, count)
     }
 
     @Test
     fun `已达扣减上限后不再扣`() {
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            currentLifeMs = 3_000L, reduceCount = 2, position = 6
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline - 4_000L,
+            nowMs = born,
+            reduceCount = SystemBubblePolicy.MAX_REDUCE_COUNT,
+            position = 6
         )
-        assertEquals(3_000L, life)
-        assertEquals(2, count)
-    }
-
-    @Test
-    fun `位置 4 已扣 1 次会继续扣到上限`() {
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            currentLifeMs = 5_000L, reduceCount = 1, position = 4
-        )
-        assertEquals(3_000L, life)
-        assertEquals(2, count)
+        assertEquals(baseDeadline - 4_000L, deadline)
+        assertEquals(SystemBubblePolicy.MAX_REDUCE_COUNT, count)
     }
 
     @Test
     fun `位置退回 1 到 3 即使有配额也不扣`() {
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            currentLifeMs = 5_000L, reduceCount = 1, position = 2
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline - 2_000L,
+            nowMs = born,
+            reduceCount = 1,
+            position = 2
         )
-        assertEquals(5_000L, life)
+        assertEquals(baseDeadline - 2_000L, deadline)
         assertEquals(1, count)
     }
 
     @Test
-    fun `寿命低于下限时钳制到下限`() {
-        // 防御：即使传入异常小值也不低于 MIN_LIFE_MS
-        val (life, count) = SystemBubblePolicy.computeNextLife(
-            currentLifeMs = 1_000L, reduceCount = 1, position = 6
+    fun `连续挤压 6 位总寿命封底在 3 秒`() {
+        var deadline = baseDeadline
+        var count = 0
+        val lives = mutableListOf<Long>()
+        repeat(5) {
+            val next = SystemBubblePolicy.computeNextDeadline(deadline, born, count, 6)
+            deadline = next.first
+            count = next.second
+            lives += deadline - born
+        }
+        assertEquals(listOf(5_000L, 3_000L, 3_000L, 3_000L, 3_000L), lives)
+        assertEquals(SystemBubblePolicy.MIN_LIFE_MS, deadline - born)
+    }
+
+    // ── 回归：扣减必须缩短寿命，不能重新计时 ────────────────
+
+    @Test
+    fun `已存活一段时间被挤旧时提前移除而不是续命`() {
+        // 已存活 4 秒（剩 3 秒）。旧实现按「剩余时长」重新倒计时：扣完剩 5 秒，
+        // 从第 4 秒起再等 5 秒 → 总寿命 9 秒，比原定 7 秒更久。
+        val now = born + 4_000L
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline,
+            nowMs = now,
+            reduceCount = 0,
+            position = 4
         )
-        assertEquals(SystemBubblePolicy.MIN_LIFE_MS, life)
-        assertEquals(2, count)
+        assertEquals("扣减后应比原到期时刻早 2 秒", baseDeadline - 2_000L, deadline)
+        assertEquals("总寿命应缩短到 5 秒", 5_000L, deadline - born)
+        assertTrue("总寿命不得超过初始寿命", deadline - born <= SystemBubblePolicy.BASE_LIFE_MS)
+        assertEquals(1, count)
     }
 
     @Test
-    fun `连续挤压 6 位封底在 3 秒不再下降`() {
-        var life = SystemBubblePolicy.BASE_LIFE_MS
-        var count = 0
-        val steps = mutableListOf<Long>()
-        repeat(5) {
-            val (next, nextCount) = SystemBubblePolicy.computeNextLife(life, count, position = 6)
-            steps += next
-            life = next
-            count = nextCount
+    fun `剩余不足一个扣减步长时钳到当前时刻立即移除`() {
+        // 已存活 6 秒（剩 1 秒），扣 2 秒会越过当前时刻
+        val now = born + 6_000L
+        val (deadline, count) = SystemBubblePolicy.computeNextDeadline(
+            deadlineMs = baseDeadline,
+            nowMs = now,
+            reduceCount = 0,
+            position = 4
+        )
+        assertEquals("不应倒退到过去，应立即到期", now, deadline)
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun `任意时刻扣减都不会让到期时刻推后`() {
+        for (elapsed in 0L..7_000L step 500L) {
+            val now = born + elapsed
+            val (deadline, _) = SystemBubblePolicy.computeNextDeadline(
+                deadlineMs = baseDeadline,
+                nowMs = now,
+                reduceCount = 0,
+                position = 4
+            )
+            assertTrue("elapsed=$elapsed 时到期时刻被推后了", deadline <= baseDeadline)
         }
-        assertEquals(listOf(5_000L, 3_000L, 3_000L, 3_000L, 3_000L), steps)
     }
 }

--- a/app/src/test/java/com/meapet/mobile/client/model/ApiResponseTest.kt
+++ b/app/src/test/java/com/meapet/mobile/client/model/ApiResponseTest.kt
@@ -2,6 +2,7 @@ package com.meapet.mobile.client.model
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ApiResponseTest {
@@ -43,5 +44,29 @@ class ApiResponseTest {
     fun chatCompletionContentExtractsMessage() {
         val body = """{"choices":[{"message":{"role":"assistant","content":"喵"}}]}"""
         assertEquals("喵", ApiResponse.chatCompletionContent(body))
+    }
+
+    @Test
+    fun errorMessageFromNestedErrorObject() {
+        val body = """{"error":{"message":"Rate limit exceeded for model gpt-4o","type":"rate_limit"}}"""
+        assertEquals("Rate limit exceeded for model gpt-4o", ApiResponse.errorMessage(body))
+    }
+
+    @Test
+    fun errorMessageFromPlainErrorString() {
+        assertEquals("invalid key", ApiResponse.errorMessage("""{"error":"invalid key"}"""))
+    }
+
+    @Test
+    fun errorMessageFromTopLevelMessage() {
+        assertEquals("quota exhausted", ApiResponse.errorMessage("""{"message":"  quota exhausted  "}"""))
+    }
+
+    @Test
+    fun errorMessageMalformedOrEmptyReturnsNull() {
+        assertNull(ApiResponse.errorMessage("not-json"))
+        assertNull(ApiResponse.errorMessage("""{"error":{"type":"rate_limit"}}"""))
+        assertNull(ApiResponse.errorMessage("""{"error":"   "}"""))
+        assertNull(ApiResponse.errorMessage("""[{"error":"array root"}]"""))
     }
 }


### PR DESCRIPTION
- 系统气泡「挤旧扣寿命」实际会延长寿命：策略原按剩余时长运算，扣减后从当前 时刻重新倒计时，已流逝的时间被丢弃——已存活 6 秒的气泡「扣 2 秒」变成再活 5 秒（总计 11 秒），比原定 7 秒更久。改为按绝对到期时刻运算 （computeNextDeadline），lifeMap 值类型换成 BubbleLife(deadlineMs, job, reduceCount)，时间基准取 SystemClock.elapsedRealtime()
- scheduleRemove 的非正延时分支改用 yield()：Main.immediate 下 delay(0) 不 挂起，协程体会同步跑在调用方写回 lifeMap 之前，留下持有已完成 Job 的僵尸条目
- API 网关错误详情不再被丢弃：ApiException.responseBody 原先无任何读取点， 用户只看到「请求过于频繁」而无从判断真因。新增 ApiResponse.errorMessage 解析网关说明并拼进用户文案（截 200 字符），原始响应体经 Log.w 落 Logcat
- MainActivity 等悬浮窗 Service 停止的 GL 恢复改为订阅 StateFlow + 2 秒超时： 原 16ms Handler 轮询在 Service 异常退出、isRunning 未置回 false 时永不终止， glSurfaceView.onResume() 永不执行 → 主界面永久黑屏
- LogExporter 的 process.waitFor() 加 5 秒超时 + destroyForcibly 兜底，避免 logcat 子进程挂起时占死 Dispatchers.IO 线程且不响应协程取消
- TTS attn 矩阵护栏改为按内存封顶（64MiB）：原 MAX_TOTAL_FRAMES=480_000 在 上游 200 字截断下永远触发不到（最坏约 180000 帧），等于没有护栏
- ChatService.retryLastMessage 补 userIdx < 0 判断：目标消息已不在历史时 drop(0) 会退化为删除整段历史的 assistant 回复
- 修正 ConversationManager 自相矛盾的类注释与 lastUserMessage 的 KDoc